### PR TITLE
FIX Ensure Page and PageController are parsed

### DIFF
--- a/src/Compare/BreakingChangesComparer.php
+++ b/src/Compare/BreakingChangesComparer.php
@@ -1402,7 +1402,13 @@ class BreakingChangesComparer
      */
     private function getModuleForFile(string $filePath): string
     {
-        $regex = '#' . CloneCommand::DIR_CLONE. '/(?:' . BreakingChangesComparer::FROM . '|' . BreakingChangesComparer::TO . ')/vendor/([^/]+/[^/]+)/#';
+        $regexPrefix = '#' . CloneCommand::DIR_CLONE. '/(?:' . BreakingChangesComparer::FROM . '|' . BreakingChangesComparer::TO . ')';
+        // Instead of trying to figure out which recipe the code from app/src came from, just accept it's from one of them.
+        if (preg_match($regexPrefix . '/app/src/#', $filePath)) {
+            return 'app/src/ dir (from one of the recipes)';
+        }
+        // Find the module name based on the vendor dir
+        $regex = $regexPrefix . '/vendor/([^/]+/[^/]+)/#';
         preg_match($regex, $filePath, $matches);
         $module = $matches[1];
         if (!$module) {

--- a/src/Parse/RecipeVersionCollection.php
+++ b/src/Parse/RecipeVersionCollection.php
@@ -38,7 +38,7 @@ class RecipeVersionCollection extends VersionCollection
      */
     public function getPackageNames(): array
     {
-        return array_keys($this->supportedModules);
+        return ['app', ...array_keys($this->supportedModules)];
     }
 
     /**
@@ -46,6 +46,9 @@ class RecipeVersionCollection extends VersionCollection
      */
     public function getPackagePath(string $package): string
     {
+        if ($package === 'app') {
+            return Path::join($this->basePath, CloneCommand::DIR_CLONE, $this->version, 'app');
+        }
         return realpath(Path::join($this->basePath, CloneCommand::DIR_CLONE, $this->version, '/vendor/', $package));
     }
 

--- a/tests/BreakingChangesComparerTest.php
+++ b/tests/BreakingChangesComparerTest.php
@@ -40,11 +40,15 @@ class BreakingChangesComparerTest extends TestCase
                 'type' => 'theme',
                 'packagist' => 'some-org/some-theme',
             ],
-            // We need to include framework with some stubs for some of the type checks
+            // We need to include these with some stubs for some of the type checks
             // e.g. checking for the configurable trait on DataObject subclasses.
             'silverstripe/framework' => [
                 'type' => 'module',
                 'packagist' => 'silverstripe/framework',
+            ],
+            'silverstripe/cms' => [
+                'type' => 'module',
+                'packagist' => 'silverstripe/cms',
             ],
         ];
         $factory = new ParserFactory($supportedModules, Path::join(__DIR__, 'fixture-code'));

--- a/tests/fixture-code/cloned/from/app/src/Page.php
+++ b/tests/fixture-code/cloned/from/app/src/Page.php
@@ -1,0 +1,8 @@
+<?php
+
+use SilverStripe\CMS\Model\SiteTree;
+
+class Page extends SiteTree
+{
+
+}

--- a/tests/fixture-code/cloned/from/vendor/silverstripe/cms/src/Model/SiteTree.php
+++ b/tests/fixture-code/cloned/from/vendor/silverstripe/cms/src/Model/SiteTree.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\CMS\Model;
+
+/**
+ * Dummy replacement for SiteTree to check the Page.php file in app/src gets included in class hierarchies.
+ */
+class SiteTree
+{
+    public function methodFromSiteTree()
+    {
+        // no-op
+    }
+}

--- a/tests/fixture-code/cloned/from/vendor/some-org/module1/code/MyPage.php
+++ b/tests/fixture-code/cloned/from/vendor/some-org/module1/code/MyPage.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SomeOrg\Module1;
+
+use Page;
+
+class MyPage extends Page
+{
+    public function methodFromSiteTree()
+    {
+        // no-op
+    }
+}

--- a/tests/fixture-code/cloned/to/app/src/Page.php
+++ b/tests/fixture-code/cloned/to/app/src/Page.php
@@ -1,0 +1,8 @@
+<?php
+
+use SilverStripe\CMS\Model\SiteTree;
+
+class Page extends SiteTree
+{
+
+}

--- a/tests/fixture-code/cloned/to/vendor/silverstripe/cms/src/Model/SiteTree.php
+++ b/tests/fixture-code/cloned/to/vendor/silverstripe/cms/src/Model/SiteTree.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\CMS\Model;
+
+/**
+ * Dummy replacement for SiteTree to check the Page.php file in app/src gets included in class hierarchies.
+ */
+class SiteTree
+{
+    public function methodFromSiteTree()
+    {
+        // no-op
+    }
+}

--- a/tests/fixture-code/cloned/to/vendor/some-org/module1/src/MyPage.php
+++ b/tests/fixture-code/cloned/to/vendor/some-org/module1/src/MyPage.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace SomeOrg\Module1;
+
+use Page;
+
+class MyPage extends Page
+{
+}


### PR DESCRIPTION
These are needed to correctly identify the full class hierarchy of anything that subclasses them, e.g. `RedirectorPage extends Page` needs to know about the hierarchy up through `SiteTree` etc.

Some CI failures are expected. https://github.com/silverstripe/deprecation-checker/pull/8#issuecomment-2840677926


## Issue

- https://github.com/silverstripe/.github/issues/409